### PR TITLE
Drop test database between tests

### DIFF
--- a/next-app/backend/tests/integration/classroom/createClassroom.integration.test.ts
+++ b/next-app/backend/tests/integration/classroom/createClassroom.integration.test.ts
@@ -8,14 +8,14 @@ import {
 } from "../../../constants";
 import dbConnect, { dbDisconnect } from "../../../database/dbConnect";
 import { ClassroomModel } from "../../../database/models/classroom";
-import dropDatabase from "../../../util/dropDatabase";
+import dropTestDb from "../../../util/dropTestDb";
 
 beforeAll(async () => {
   await dbConnect(DB_TEST_NAME);
 });
 
 afterAll(async () => {
-  await dropDatabase(DB_TEST_NAME);
+  await dropTestDb();
   await dbDisconnect();
 });
 

--- a/next-app/backend/tests/integration/classroom/getClassroom.integration.test.ts
+++ b/next-app/backend/tests/integration/classroom/getClassroom.integration.test.ts
@@ -8,14 +8,14 @@ import {
 } from "../../../constants";
 import dbConnect, { dbDisconnect } from "../../../database/dbConnect";
 import { ClassroomModel } from "../../../database/models/classroom";
-import dropDatabase from "../../../util/dropDatabase";
+import dropTestDb from "../../../util/dropTestDb";
 
 beforeAll(async () => {
   await dbConnect(DB_TEST_NAME);
 });
 
 afterAll(async () => {
-  await dropDatabase(DB_TEST_NAME);
+  await dropTestDb();
   await dbDisconnect();
 });
 

--- a/next-app/backend/tests/integration/classroom/getClassrooms.integration.test.ts
+++ b/next-app/backend/tests/integration/classroom/getClassrooms.integration.test.ts
@@ -10,14 +10,14 @@ import {
 } from "../../../constants";
 import dbConnect, { dbDisconnect } from "../../../database/dbConnect";
 import zip from "../../../util/zip";
-import dropDatabase from "../../../util/dropDatabase";
+import dropTestDb from "../../../util/dropTestDb";
 
 beforeAll(async () => {
   await dbConnect(DB_TEST_NAME);
 });
 
 afterAll(async () => {
-  await dropDatabase(DB_TEST_NAME);
+  await dropTestDb();
   await dbDisconnect();
 });
 

--- a/next-app/backend/tests/integration/enrollment/createEnrollment.integration.test.ts
+++ b/next-app/backend/tests/integration/enrollment/createEnrollment.integration.test.ts
@@ -9,18 +9,18 @@ import {
   CLASSROOM_TEST_TITLE,
   DB_TEST_NAME,
   MAX_CLASSROOM_SIZE,
-  TEST_INSTRUCTOR_ID
+  TEST_INSTRUCTOR_ID,
 } from "../../../constants";
 import dbConnect, { dbDisconnect } from "../../../database/dbConnect";
 import { ClassroomModel } from "../../../database/models/classroom";
-import dropDatabase from "../../../util/dropDatabase";
+import dropTestDb from "../../../util/dropTestDb";
 
 beforeAll(async () => {
   await dbConnect(DB_TEST_NAME);
 });
 
 afterAll(async () => {
-  await dropDatabase(DB_TEST_NAME)
+  await dropTestDb();
   await dbDisconnect();
 });
 

--- a/next-app/backend/tests/integration/login.integration.test.ts
+++ b/next-app/backend/tests/integration/login.integration.test.ts
@@ -7,14 +7,14 @@ import { UserModel } from "../../database/models/user";
 import { AUTH0_TEST_ID, DB_TEST_NAME } from "../../constants";
 import { login } from "../../helpers/login";
 import { User } from "../../types";
-import dropDatabase from "../../util/dropDatabase";
+import dropTestDb from "../../util/dropTestDb";
 
 beforeAll(async () => {
   await dbConnect(DB_TEST_NAME);
 });
 
 afterAll(async () => {
-  await dropDatabase(DB_TEST_NAME);
+  await dropTestDb();
   await dbDisconnect();
 });
 

--- a/next-app/backend/tests/unit/dropTestDb.unit.test.ts
+++ b/next-app/backend/tests/unit/dropTestDb.unit.test.ts
@@ -1,13 +1,13 @@
 import { expect, test } from "@jest/globals";
 import dbConnect from "../../database/dbConnect";
-import dropDatabase from "../../util/dropDatabase";
+import dropTestDb from "../../util/dropTestDb";
 import {
   AUTH0_TEST_ID,
   AUTH0_TEST_USER_NAME,
   DB_TEST_NAME,
-} from "./../../constants";
-import { dbDisconnect } from "./../../database/dbConnect";
-import { UserModel } from "./../../database/models/user";
+} from "../../constants";
+import { dbDisconnect } from "../../database/dbConnect";
+import { UserModel } from "../../database/models/user";
 
 const TEST_USER = { name: AUTH0_TEST_USER_NAME, authId: AUTH0_TEST_ID };
 
@@ -16,7 +16,7 @@ beforeAll(async () => {
 });
 
 afterAll(async () => {
-  await dropDatabase(DB_TEST_NAME);
+  await dropTestDb();
   await dbDisconnect();
 });
 
@@ -24,6 +24,6 @@ test("Properly drops a test database", async () => {
   await UserModel.create(TEST_USER);
   expect(await UserModel.findOne(TEST_USER)).not.toBeNull();
 
-  await dropDatabase(DB_TEST_NAME);
+  await dropTestDb();
   expect(await UserModel.findOne(TEST_USER)).toBeNull();
 });

--- a/next-app/backend/util/dropDatabase.ts
+++ b/next-app/backend/util/dropDatabase.ts
@@ -1,6 +1,0 @@
-import dbConnect from "../database/dbConnect";
-
-export default async function dropDatabase(name: string) {
-  await dbConnect(name);
-  await mongooseInst.conn?.connection.dropDatabase();
-}

--- a/next-app/backend/util/dropTestDb.ts
+++ b/next-app/backend/util/dropTestDb.ts
@@ -1,0 +1,7 @@
+import dbConnect from "../database/dbConnect";
+import { DB_TEST_NAME } from "./../constants";
+
+export default async function dropTestDb() {
+  await dbConnect(DB_TEST_NAME);
+  await mongooseInst.conn?.connection.dropDatabase();
+}


### PR DESCRIPTION
This PR fixes the test issues I mentioned during today's scrum meeting.

* Added a ``dropDatabase`` helper function
* Updated all tests that use the test DB to drop it after finishing