### PR TITLE
Allow users to copy the access code for their classrooms

### DIFF
--- a/next-app/components/AlertButton.tsx
+++ b/next-app/components/AlertButton.tsx
@@ -1,47 +1,63 @@
-import CloseIcon from '@mui/icons-material/Close'
-import { Alert, AlertProps, Button, ButtonProps, Snackbar, SnackbarProps } from "@mui/material"
-import { Box } from '@mui/system'
-import { useState } from "react"
+import CloseIcon from "@mui/icons-material/Close";
+import {
+  Alert,
+  AlertProps,
+  Button,
+  ButtonProps,
+  Snackbar,
+  SnackbarProps,
+} from "@mui/material";
+import { Box } from "@mui/system";
+import { useState } from "react";
 
 export interface SnackbarButtonProps {
-    buttonText: string
-    alertContent: React.ReactNode
-    buttonProps?: ButtonProps
-    snackbarProps?: SnackbarProps
-    alertProps?: AlertProps
+  buttonText: string;
+  alertContent: React.ReactNode;
+  buttonProps?: ButtonProps;
+  snackbarProps?: SnackbarProps;
+  alertProps?: AlertProps;
 }
 
-export default function AlertButton({ buttonText, alertContent, buttonProps, snackbarProps, alertProps, }: SnackbarButtonProps) {
-    const [open, setOpen] = useState(false)
-    const openAlert = () => setOpen(true)
-    const closeAlert = () => setOpen(false)
+export default function AlertButton({
+  buttonText,
+  alertContent,
+  buttonProps,
+  snackbarProps,
+  alertProps,
+}: SnackbarButtonProps) {
+  const [open, setOpen] = useState(false);
+  const openAlert = () => setOpen(true);
+  const closeAlert = () => setOpen(false);
 
-
-    return <>
-        <Button {...buttonProps} onClick={(e) => {
-            openAlert()
-            buttonProps?.onClick && buttonProps.onClick(e)
-        }} >
-            {buttonText}
-        </Button>
-        <Snackbar
-            anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
-            open={open}
-            {...snackbarProps}
-        >
-            <Alert
-                severity="error"
-                {...alertProps}
-            >
-                <Box
-                    sx={{ display: "flex", flexDirection: "row", justifyContent: "space-between" }}
-
-                >
-                    {alertContent}
-                    <CloseIcon sx={{ cursor: "pointer" }} onClick={closeAlert} />
-                </Box>
-            </Alert>
-
-        </Snackbar>
+  return (
+    <>
+      <Button
+        {...buttonProps}
+        onClick={(e) => {
+          openAlert();
+          buttonProps?.onClick && buttonProps.onClick(e);
+        }}
+      >
+        {buttonText}
+      </Button>
+      <Snackbar
+        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+        open={open}
+        {...snackbarProps}
+      >
+        <Alert severity="error" {...alertProps}>
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: "row",
+              justifyContent: "space-between",
+            }}
+          >
+            {alertContent}
+            <CloseIcon sx={{ cursor: "pointer" }} onClick={closeAlert} />
+          </Box>
+        </Alert>
+      </Snackbar>
     </>
+  );
 }

--- a/next-app/components/home_page/userclassroom/userclassroomcard.tsx
+++ b/next-app/components/home_page/userclassroom/userclassroomcard.tsx
@@ -3,10 +3,11 @@ import {
   Button,
   Card,
   CardContent,
-  CardMedia, styled,
-  Typography
+  CardMedia,
+  styled,
+  Typography,
 } from "@mui/material";
-import Link from 'next/link';
+import Link from "next/link";
 import React, { FC } from "react";
 import { Classroom } from "../../../interfaces/classroom.interface";
 import AlertButton from "../../AlertButton";
@@ -36,7 +37,7 @@ const UserClassroomCard: FC<UserClassroomCardProp> = ({
     if (accessCode) {
       navigator.clipboard.writeText(accessCode);
     }
-  }
+  };
 
   return (
     <ClassroomCard
@@ -58,7 +59,14 @@ const UserClassroomCard: FC<UserClassroomCardProp> = ({
             {title}
           </Typography>
         </CardContent>
-        <Box sx={{ display: "flex", justifyContent: "space-between", margin: "0.5rem", maxWidth: "200px" }}>
+        <Box
+          sx={{
+            display: "flex",
+            justifyContent: "space-between",
+            margin: "0.5rem",
+            maxWidth: "200px",
+          }}
+        >
           <Link href={`/app/classroom/${classroom._id}`}>
             <Button variant="contained" size="small">
               View
@@ -69,20 +77,35 @@ const UserClassroomCard: FC<UserClassroomCardProp> = ({
               <Button variant="contained" size="small">
                 Edit
               </Button>
-              {accessCode &&
+              {accessCode && (
                 <AlertButton
                   buttonText="Invite"
                   alertContent={
                     <Typography variant="body1">
                       Copied access code to clipboard:&nbsp;
-                      <div onClick={() => { copyAccessCodeToClipboard(); window.alert("Copied!") }} style={{ textDecoration: "underline", display: "inline", cursor: "pointer" }}>{accessCode}</div>
-                    </Typography>}
+                      <div
+                        onClick={() => {
+                          copyAccessCodeToClipboard();
+                          window.alert("Copied!");
+                        }}
+                        style={{
+                          textDecoration: "underline",
+                          display: "inline",
+                          cursor: "pointer",
+                        }}
+                      >
+                        {accessCode}
+                      </div>
+                    </Typography>
+                  }
                   buttonProps={{
-                    variant: "contained", size: "small", onClick: copyAccessCodeToClipboard
+                    variant: "contained",
+                    size: "small",
+                    onClick: copyAccessCodeToClipboard,
                   }}
                   alertProps={{ severity: "info" }}
                 />
-              }
+              )}
             </>
           )}
         </Box>


### PR DESCRIPTION
After creating a classroom, get its access code by clicking "Invite." It is then copied to the clipboard.

You can copy the access code again by clicking it in the feedback alert.

Users can join the classroom by entering an access code through "Join a classroom." (Thanks for handling all the logic @emmanuelgamboa09!) 

![image](https://user-images.githubusercontent.com/46092255/157799590-15229d99-4f34-442d-a8cb-f73e9c72b1a2.png)

![image](https://user-images.githubusercontent.com/46092255/157799595-0aede11c-4c27-414b-98cb-83b8b96d82de.png)
