### PR TITLE
removed outgoingTeamRequests field and moved incomingTeamRequests 

### DIFF
--- a/next-app/backend/database/models/project/teamRequestSchema.ts
+++ b/next-app/backend/database/models/project/teamRequestSchema.ts
@@ -1,0 +1,20 @@
+import * as mongoose from "mongoose";
+const { Schema } = mongoose;
+
+export type TeamRequestChoice = "yes" | "no" | "maybe";
+
+export interface TeamRequest {
+  _id?: string;
+  teamId: string;
+  choice: TeamRequestChoice;
+}
+
+const teamRequestSchema = new Schema<TeamRequest>({
+  teamId: { type: String, required: true },
+  choice: {
+    type: String,
+    required: true,
+  },
+});
+
+export default teamRequestSchema;

--- a/next-app/backend/database/models/project/teamSchema.ts
+++ b/next-app/backend/database/models/project/teamSchema.ts
@@ -1,4 +1,5 @@
 import * as mongoose from "mongoose";
+import teamRequestSchema, { TeamRequest } from "./teamRequestSchema";
 const { model, Schema } = mongoose;
 
 export interface Team {
@@ -6,6 +7,7 @@ export interface Team {
   name: string;
   description?: string;
   teamMembers?: string[];
+  incomingTeamRequests?: TeamRequest[];
 }
 
 const teamSchema = new Schema<Team>({
@@ -14,6 +16,11 @@ const teamSchema = new Schema<Team>({
   // TODO: Foreign key constraint -- ensure inserted Project Users exist
   // TODO: Ensure team size doesn't exceed the Project team size limit
   teamMembers: { type: [String], required: false, default: [] },
+  incomingTeamRequests: {
+    type: [teamRequestSchema],
+    required: true,
+    default: [],
+  },
 });
 
 export default teamSchema;

--- a/next-app/backend/database/models/project/userProjectProfileSchema.ts
+++ b/next-app/backend/database/models/project/userProjectProfileSchema.ts
@@ -5,16 +5,12 @@ export interface UserProjectProfile {
   studentId: string;
   projectBio?: string;
   desiredRoles?: string[];
-  incomingTeamRequests: string[];
-  outgoingTeamRequests: string[];
 }
 
 export const userProjectProfileSchema = new Schema<UserProjectProfile>({
   studentId: { type: String, required: true },
   projectBio: { type: String, required: false, default: "" },
   desiredRoles: { type: [String], required: false, default: [] },
-  incomingTeamRequests: { type: [String], required: true, default: [] },
-  outgoingTeamRequests: { type: [String], required: true, default: [] },
 });
 
 export const UserProjectProfileModel =

--- a/next-app/backend/tests/integration/project-users/createProjectUser.integration.test.ts
+++ b/next-app/backend/tests/integration/project-users/createProjectUser.integration.test.ts
@@ -93,8 +93,6 @@ test("Insert project for existing classroom with save operation successful", asy
     studentId: AUTH0_TEST_ID,
     projectBio: PROJECT_PROFILE_TEST_BIO,
     desiredRoles: PROJECT_PROFILE_TEST_DESIRED_ROLES,
-    incomingTeamRequests: [],
-    outgoingTeamRequests: [],
   });
 
   await ProjectModel.deleteOne({
@@ -189,8 +187,6 @@ test("Insert project user but profile already exists", async () => {
         studentId: AUTH0_TEST_ID,
         projectBio: PROJECT_PROFILE_TEST_BIO,
         desiredRoles: PROJECT_PROFILE_TEST_DESIRED_ROLES,
-        incomingTeamRequests: [],
-        outgoingTeamRequests: [],
       },
     ],
   };
@@ -233,8 +229,6 @@ test("Insert project user but profile already exists", async () => {
     studentId: AUTH0_TEST_ID,
     projectBio: PROJECT_PROFILE_TEST_BIO,
     desiredRoles: PROJECT_PROFILE_TEST_DESIRED_ROLES,
-    incomingTeamRequests: [],
-    outgoingTeamRequests: [],
   });
 
   await ProjectModel.deleteOne({

--- a/next-app/backend/tests/integration/project-users/updateProjectUser.integration.test.ts
+++ b/next-app/backend/tests/integration/project-users/updateProjectUser.integration.test.ts
@@ -62,8 +62,6 @@ test("Update project for existing classroom with save operation successful", asy
         projectBio: "bio",
         desiredRoles: PROJECT_PROFILE_TEST_DESIRED_ROLES,
         studentId: AUTH0_TEST_ID,
-        incomingTeamRequests: [],
-        outgoingTeamRequests: [],
       },
     ],
   };
@@ -112,8 +110,6 @@ test("Update project for existing classroom with save operation successful", asy
     projectBio: "UPDATED BIO",
     desiredRoles: ["a", "b"],
     studentId: AUTH0_TEST_ID,
-    incomingTeamRequests: [],
-    outgoingTeamRequests: [],
   });
 
   await ProjectModel.deleteOne({
@@ -151,8 +147,6 @@ test("Update project user but with invalid body", async () => {
         projectBio: "bio",
         desiredRoles: PROJECT_PROFILE_TEST_DESIRED_ROLES,
         studentId: AUTH0_TEST_ID,
-        incomingTeamRequests: [],
-        outgoingTeamRequests: [],
       },
     ],
   };
@@ -196,8 +190,6 @@ test("Update project user but with invalid body", async () => {
       projectBio: "bio",
       desiredRoles: PROJECT_PROFILE_TEST_DESIRED_ROLES,
       studentId: AUTH0_TEST_ID,
-      incomingTeamRequests: [],
-      outgoingTeamRequests: [],
     },
   ]);
 
@@ -286,8 +278,6 @@ test("Update project user but user not enrolled in class", async () => {
         projectBio: "bio",
         desiredRoles: PROJECT_PROFILE_TEST_DESIRED_ROLES,
         studentId: AUTH0_TEST_ID,
-        incomingTeamRequests: [],
-        outgoingTeamRequests: [],
       },
     ],
   };
@@ -336,8 +326,6 @@ test("Update project user but user not enrolled in class", async () => {
       projectBio: "bio",
       desiredRoles: PROJECT_PROFILE_TEST_DESIRED_ROLES,
       studentId: AUTH0_TEST_ID,
-      incomingTeamRequests: [],
-      outgoingTeamRequests: [],
     },
   ]);
 


### PR DESCRIPTION
Having both an incoming and outgoing team requests field requires us to update in several places which raises consistency concerns, so I removed outgoingTeamRequests.

I'd like to move forward with the idea that each student starts out in a group of 1, since this will simplifying the group merging process significantly. It makes sense that the incomingTeamRequests field should belong to a team rather than a particular user in this case.