### PR TITLE
Project page and profile page cleanup

### DIFF
--- a/next-app/components/CustomTabs.tsx
+++ b/next-app/components/CustomTabs.tsx
@@ -1,4 +1,4 @@
-import { Tab, Tabs } from "@mui/material";
+import { SxProps, Tab, Tabs, Theme } from "@mui/material";
 import { useState } from "react";
 
 export type CustomTabs = { [name: string]: { content: JSX.Element } };
@@ -6,9 +6,10 @@ export type CustomTabs = { [name: string]: { content: JSX.Element } };
 export interface CustomTabsProps {
   tabs: CustomTabs;
   initialTab?: string;
+  tabsSxProp?: SxProps<Theme> | undefined;
 }
 
-const CustomTabs = ({ tabs, initialTab }: CustomTabsProps) => {
+const CustomTabs = ({ tabs, initialTab, tabsSxProp }: CustomTabsProps) => {
   const [tab, setTab] = useState<string>(initialTab ?? Object.keys(tabs)[0]);
   return (
     <>
@@ -17,6 +18,7 @@ const CustomTabs = ({ tabs, initialTab }: CustomTabsProps) => {
         onChange={(_, newValue) => setTab(newValue)}
         aria-label="tabs"
         centered
+        sx={tabsSxProp}
       >
         {Object.keys(tabs).map((name) => {
           return (
@@ -29,7 +31,11 @@ const CustomTabs = ({ tabs, initialTab }: CustomTabsProps) => {
   );
 };
 
-export const CustomScrollableTabs = ({ tabs, initialTab }: CustomTabsProps) => {
+export const CustomScrollableTabs = ({
+  tabs,
+  initialTab,
+  tabsSxProp,
+}: CustomTabsProps) => {
   const [tab, setTab] = useState<string>(initialTab ?? Object.keys(tabs)[0]);
 
   return (
@@ -41,6 +47,7 @@ export const CustomScrollableTabs = ({ tabs, initialTab }: CustomTabsProps) => {
         allowScrollButtonsMobile
         onChange={(_, newValue) => setTab(newValue)}
         aria-label="tabs"
+        sx={tabsSxProp}
       >
         {Object.keys(tabs).map((name) => {
           return (

--- a/next-app/components/ReadMoreText.tsx
+++ b/next-app/components/ReadMoreText.tsx
@@ -35,7 +35,7 @@ const ReadMoreText = ({
   };
 
   return (
-    <Typography component="body" fontSize="16px">
+    <Typography variant="body1">
       {content.length > cutoffLength ? (
         <>
           {content.slice(0, cutoffLength)}...

--- a/next-app/components/classroom/project/MyTeam.tsx
+++ b/next-app/components/classroom/project/MyTeam.tsx
@@ -10,10 +10,10 @@ export type MyTeamProps = {
 const MyTeam = ({ myTeam: { teamProjectUsers } }: MyTeamProps) => {
   return (
     <Box>
-      <Typography component="h2" fontSize="32px">
-        My Team
-      </Typography>
-      <Stack sx={{ flexDirection: { xs: "column", sm: "row" }, gap: "1rem" }}>
+      <Typography variant="h3">My Team</Typography>
+      <Stack
+        sx={{ flexDirection: { xs: "column", sm: "row" }, gap: "1rem", pt: 1 }}
+      >
         {teamProjectUsers.map(
           (
             { name = "MISSING_NAME", desiredRoles = [], projectBio = "" },

--- a/next-app/components/classroom/project/TeamFinderProjectTab.tsx
+++ b/next-app/components/classroom/project/TeamFinderProjectTab.tsx
@@ -141,7 +141,7 @@ const FinalizeGroupsButton = ({
   projectId,
   groupsFinalized,
 }: FinalizeGroupsButtonProps) => {
-  const { mutate: finalizeGroups, isLoading } = useMutation(
+  const { mutate: finalizeGroups, isLoading: finalizingGroups } = useMutation(
     () => {
       return fetch(`/api/projects/${projectId}/finalize-groups`, {
         method: "PUT",
@@ -150,9 +150,6 @@ const FinalizeGroupsButton = ({
     {
       onError(error) {
         console.error(error);
-      },
-      async onSuccess(result) {
-        console.log(await result.text());
       },
     },
   );
@@ -170,10 +167,10 @@ const FinalizeGroupsButton = ({
       variant="outlined"
       color="error"
       endIcon={<AssignmentIndIcon />}
-      disabled={groupsFinalized}
+      disabled={finalizingGroups || groupsFinalized}
       onClick={handleClick}
     >
-      {isLoading
+      {finalizingGroups
         ? "Finalizing Groups..."
         : groupsFinalized
         ? "Groups Finalized"

--- a/next-app/pages/app/classroom/[classroomId]/projects/[projectId]/index.tsx
+++ b/next-app/pages/app/classroom/[classroomId]/projects/[projectId]/index.tsx
@@ -69,7 +69,7 @@ const ProjectPage: NextPageWithLayout = () => {
 
   return (
     <>
-      <Typography variant="h3" pt={2}>
+      <Typography variant="h2" pt={2}>
         {title ? title : "Untitled Project"}
       </Typography>
       {isInstructor && (
@@ -87,14 +87,9 @@ const ProjectPage: NextPageWithLayout = () => {
           "Project Details": {
             content: (
               <>
-                <Typography component="h2" fontSize="32px">
-                  Project Details
-                </Typography>
-
+                <Typography variant="h3">Project Details</Typography>
                 {description && (
-                  <Typography component="p" fontSize="16px">
-                    {description}
-                  </Typography>
+                  <Typography variant="h6">{description}</Typography>
                 )}
               </>
             ),
@@ -111,6 +106,7 @@ const ProjectPage: NextPageWithLayout = () => {
             ? { "My Team": { content: <MyTeam myTeam={myTeam} /> } }
             : {}),
         }}
+        tabsSxProp={{ my: 1 }}
       />
     </>
   );

--- a/next-app/pages/app/classroom/[classroomId]/projects/[projectId]/profile/[profileId].tsx
+++ b/next-app/pages/app/classroom/[classroomId]/projects/[projectId]/profile/[profileId].tsx
@@ -203,7 +203,7 @@ const ProfilePage: NextPageWithLayout<ProfilePageProps> = ({
   };
 
   return (
-    <Box margin="2rem">
+    <Box paddingY={2}>
       {project.data?.title && (
         <Typography component="sub" fontSize="16px">
           {project.data?.title}


### PR DESCRIPTION
1. Change font size so tabs in project page would all match.
2. added ability to add sx value to tabs, inorder to put some styling since mobile felt squishedtogether
3. Disabled finalize groups button when client call is being made so the teacher can't spam the button when the client call is being made.
4. Change margin for padding in project profile page, when I updated the layout it removed the need to apply margin to the pages, so this is no longer needed. Changed it to padding just to push it down a bit.